### PR TITLE
fix(ui): prevent users from turning start/finish nodes into walls

### DIFF
--- a/src/Algorithms/Path.jsx
+++ b/src/Algorithms/Path.jsx
@@ -106,6 +106,7 @@ const Path = () => {
   const WallChange = (grid, row, col) => {
     const newGrid = [...grid];
     const node = newGrid[row][col];
+    if (node.isStart || node.isFinish) return grid;
     const newNode = {
       ...node,
       isWall: !node.isWall,


### PR DESCRIPTION
Title: Prevent start/finish tiles from becoming walls

Description:

Added an if statement (Path.jsx) to check if the node selected is the start node or target node. If so, returns grid unchanged.

Users could break the path by clicking the target or the start, leading to a path algorithm that searches the entire grid.